### PR TITLE
adds the base for score and its bucket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,7 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# Needed by the demo
 .env
+.data/

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ REPO=COLLAB
 
 #========================= Docker commands ===========================#
 start:
+	source .env
 	docker-compose up -d
 
 stop:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -174,8 +174,8 @@ services:
       S3_ACCESSKEY: minio
       S3_SECRETKEY: minio123
       AUTH_SERVER_URL: http://ego-api:8088/o/check_token/
-      AUTH_SERVER_CLIENTID:  3kJhz9pNtC0pFHAxr2SPkUkGjXrkWWqGcnPC0vBP
-      AUTH_SERVER_CLIENTSECRET: v9mjRtuEVwpt7cgqnsq6mxtCa5FbUOpKLGh7WX8a1dWbBKfrM3iV3VYMtE60jr3W7GLWtNeYIaJ8EUxPkaInclWVXf64qKdR3IKwyfpDU7JhvWEwIYQYdwV1YAUZjB2e
+      AUTH_SERVER_CLIENTID:  score
+      AUTH_SERVER_CLIENTSECRET: scoresecret
       AUTH_SERVER_UPLOADSCOPE: demo.WRITE
       AUTH_SERVER_DOWNLOADSCOPE: demo.READ
       SERVER_URL: http://localhost:8080

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -144,5 +144,53 @@ services:
       KAFKA_REST_BOOTSTRAP_SERVERS: kafka.local:29092
       KAFKA_REST_LISTENERS: "http://0.0.0.0:8082"
 
+  #####################################################
+  # Score
+  #####################################################
+  object-storage:
+    image: minio/minio:RELEASE.2018-05-11T00-29-24Z
+    network_mode: host
+    volumes:
+      - "./.data/minio:/opt/dcc/data"
+    environment:
+      MINIO_ACCESS_KEY: minio
+      MINIO_SECRET_KEY: minio123
+      MINIO_PORT: 8085
+    deploy:
+        restart_policy:
+            delay: 10s
+            max_attempts: 10
+            window: 60s
+    command: server --address=0.0.0.0:8085 /opt/dcc/data
+  score-server:
+    build: ./score_bootstrap
+    network_mode: host
+    depends_on:
+      - ego-api
+      - object-storage
+    environment:
+      DCC_DATA: /opt/dcc/data
+      OBJECT_STORAGE_URL: http://localhost:8085
+      S3_ACCESSKEY: minio
+      S3_SECRETKEY: minio123
+      AUTH_SERVER_URL: http://ego-api:8088/o/check_token/
+      AUTH_SERVER_CLIENTID:  3kJhz9pNtC0pFHAxr2SPkUkGjXrkWWqGcnPC0vBP
+      AUTH_SERVER_CLIENTSECRET: v9mjRtuEVwpt7cgqnsq6mxtCa5FbUOpKLGh7WX8a1dWbBKfrM3iV3VYMtE60jr3W7GLWtNeYIaJ8EUxPkaInclWVXf64qKdR3IKwyfpDU7JhvWEwIYQYdwV1YAUZjB2e
+      AUTH_SERVER_UPLOADSCOPE: demo.WRITE
+      AUTH_SERVER_DOWNLOADSCOPE: demo.READ
+      SERVER_URL: http://localhost:8080
+      SERVER_PORT: 8087
+      BUCKET_NAME_OBJECT: oicr.icgc.test
+      BUCKET_NAME_STATE: oicr.icgc.test
+      COLLABORATORY_DATA_DIRECTORY: data
+      OBJECT_SENTINEL: heliograph
+      METADATA_URL: "https://song.cancercollaboratory.org"
+    ports:
+      - 8087:8087
+    volumes:
+      - "./.data:/opt/dcc/data"
+    restart: always
+
 volumes:
   elasticsearch_data:
+

--- a/ego_bootstrap/V13__Bootstrap_Demo.sql
+++ b/ego_bootstrap/V13__Bootstrap_Demo.sql
@@ -8,7 +8,15 @@ VALUES
     'http://localhost:3501',
     'admin ui',
     'APPROVED',
-    'ADMIN');
+    'ADMIN'),
+    ('bea3aceb-91a5-4c97-9d53-14beb3af988d',
+    'score server',
+    'score',
+    'scoresecret',
+    'http://localhost:8087',
+    'score server',
+    'APPROVED',
+    'CLIENT');
 
 INSERT INTO egouser
     (id, name, email, type, firstname, lastname, createdat, lastlogin, status, preferredlanguage)

--- a/score_bootstrap/Dockerfile
+++ b/score_bootstrap/Dockerfile
@@ -1,0 +1,10 @@
+FROM overture/score-server:1.6.1
+
+ENV DCC_HOME /opt/dcc
+ENV DCC_SCRIPTS $DCC_HOME/scripts
+
+ADD scripts $DCC_SCRIPTS
+
+CMD mkdir -p  $SCORE_HOME $SCORE_LOGS && \
+    /bin/sh -c $DCC_SCRIPTS/create-buckets.sh && \
+    java -Dlog.path=$SCORE_LOGS -jar $JAR_FILE

--- a/score_bootstrap/scripts/create-buckets.sh
+++ b/score_bootstrap/scripts/create-buckets.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+echo '$DCC_DATA='$DCC_DATA
+echo '$BUCKET_NAME_OBJECT='$BUCKET_NAME_OBJECT
+echo '$BUCKET_NAME_STATE='$BUCKET_NAME_STATE
+echo '$COLLABORATORY_DATA_DIRECTORY='$COLLABORATORY_DATA_DIRECTORY
+echo '$OBJECT_SENTINEL='$OBJECT_SENTINEL
+
+function setup_bucket {
+	bucket=$1
+	data_dir=${COLLABORATORY_DATA_DIRECTORY}
+	sentinel_object=${OBJECT_SENTINEL}
+	dir=$DCC_DATA/minio/$bucket/$data_dir
+	if [ ! -d $dir ]; then
+		mkdir -p $dir
+	fi
+
+	sentinel="$dir/$sentinel_object"
+	if [ ! -f $sentinel ]; then
+		echo "Touching \"$sentinel\""
+		touch $sentinel
+	fi
+}
+
+setup_bucket $BUCKET_NAME_OBJECT
+setup_bucket $BUCKET_NAME_STATE


### PR DESCRIPTION
- updated make file to source the `.env` before trying to run `docker-compose up`
- minio service has been added to provide S3 compatible storage. 
- score server added with init script to create bucket and sentinel object. This wraps the official score-1.6.1 server. 

Todo:
- link with SONG once that is part of the docker-compose. 
- create permissions and tokens for the demo user. 